### PR TITLE
Add init command with config file support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,8 @@ Instructions for copilot
 * pylint duplicate code warnings in test are acceptable
 * before implementing news features write the unit test for the feature. work test driven.
 * testsuite must always pass
+* you must not cheat to make pylint pass. no disabling of checks allowed.
+* use info from the github action workflow to check if the code is working.
 * use no deprecated functions and methods.
 * format according pep8
 * all documentation must be in english and up to date.

--- a/tests/test_add_to_queue.py
+++ b/tests/test_add_to_queue.py
@@ -119,6 +119,7 @@ class TestAddToQueue(unittest.TestCase):
 
         # Mock datetime to control timestamp
         fixed_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
         class FixedDateTime(datetime):
             """Mock datetime class for fixed timestamp in tests."""
             @classmethod
@@ -151,7 +152,8 @@ class TestAddToQueue(unittest.TestCase):
             test_queue_manager = AddToQueue()
 
             with self.assertRaises(sqlite3.OperationalError):
-                test_queue_manager.add_url("https://www.youtube.com/watch?v=test")
+                test_queue_manager.add_url(
+                    "https://www.youtube.com/watch?v=test")
 
     def test_add_url_edge_case_empty_result(self):
         """Test duplicate URL handling when database query returns no result."""

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -32,7 +32,8 @@ class TestCreateConfig(unittest.TestCase):
         self.addCleanup(self.patcher_config_dir.stop)
         self.addCleanup(self.patcher_data_dir.stop)
 
-        self.config_file_path = Path(self.temp_config_dir.name) / CONFIG_FILE_NAME
+        self.config_file_path = Path(
+            self.temp_config_dir.name) / CONFIG_FILE_NAME
 
     def test_create_default_config_new_file(self):
         """Test that a new config file is created when it doesn't exist."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -160,7 +160,6 @@ class TestYTDLManagerDaemon(unittest.TestCase):
 
         self.assertEqual(retries, 2)
 
-    @patch.dict(os.environ, {'TARGET_FOLDER': 'test_downloads'})
     @patch('yt_dl_manager.daemon.yt_dlp.YoutubeDL')
     @patch('builtins.print')
     def test_download_media_success(self, mock_print, mock_ytdl_class):
@@ -182,8 +181,14 @@ class TestYTDLManagerDaemon(unittest.TestCase):
         test_url = "https://www.youtube.com/watch?v=test"
         row_id = self._insert_test_download(test_url)
 
-        # Test download
-        self.daemon.download_media(row_id, test_url, 0)
+        # Mock config to provide TARGET_FOLDER
+        with patch('yt_dl_manager.daemon.config') as mock_config:
+            mock_default_section = MagicMock()
+            mock_default_section.__getitem__.return_value = 'test_downloads'
+            mock_config.__getitem__.return_value = mock_default_section
+
+            # Test download
+            self.daemon.download_media(row_id, test_url, 0)
 
         # Verify yt-dlp was called correctly
         mock_ytdl_instance.extract_info.assert_called_once_with(
@@ -209,7 +214,6 @@ class TestYTDLManagerDaemon(unittest.TestCase):
         # Verify success message was printed
         mock_print.assert_called_with("Downloaded: /path/to/test_video.mp4")
 
-    @patch.dict(os.environ, {'TARGET_FOLDER': 'test_downloads'})
     @patch('yt_dl_manager.daemon.yt_dlp.YoutubeDL')
     @patch('builtins.print')
     def test_download_media_failure_with_retry(self, mock_print, mock_ytdl_class):
@@ -227,8 +231,14 @@ class TestYTDLManagerDaemon(unittest.TestCase):
         test_url = "https://www.youtube.com/watch?v=test"
         row_id = self._insert_test_download(test_url)
 
-        # Test download with retry count below max
-        self.daemon.download_media(row_id, test_url, 1)
+        # Mock config to provide TARGET_FOLDER
+        with patch('yt_dl_manager.daemon.config') as mock_config:
+            mock_default_section = MagicMock()
+            mock_default_section.__getitem__.return_value = 'test_downloads'
+            mock_config.__getitem__.return_value = mock_default_section
+
+            # Test download with retry count below max
+            self.daemon.download_media(row_id, test_url, 1)
 
         # Verify database was updated for retry
         conn = sqlite3.connect(self.test_db_path)
@@ -250,7 +260,6 @@ class TestYTDLManagerDaemon(unittest.TestCase):
         )
         mock_print.assert_called_with(expected_message)
 
-    @patch.dict(os.environ, {'TARGET_FOLDER': 'test_downloads'})
     @patch('yt_dl_manager.daemon.yt_dlp.YoutubeDL')
     @patch('builtins.print')
     def test_download_media_failure_max_retries(self, mock_print, mock_ytdl_class):
@@ -268,8 +277,14 @@ class TestYTDLManagerDaemon(unittest.TestCase):
         test_url = "https://www.youtube.com/watch?v=test"
         row_id = self._insert_test_download(test_url, retries=MAX_RETRIES-1)
 
-        # Test download at max retries
-        self.daemon.download_media(row_id, test_url, MAX_RETRIES-1)
+        # Mock config to provide TARGET_FOLDER
+        with patch('yt_dl_manager.daemon.config') as mock_config:
+            mock_default_section = MagicMock()
+            mock_default_section.__getitem__.return_value = 'test_downloads'
+            mock_config.__getitem__.return_value = mock_default_section
+
+            # Test download at max retries
+            self.daemon.download_media(row_id, test_url, MAX_RETRIES-1)
 
         # Verify database was updated to failed
         conn = sqlite3.connect(self.test_db_path)

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -46,12 +46,14 @@ class TestDatabaseUtils(unittest.TestCase):
         cur.execute(
             "INSERT INTO downloads (url, status, timestamp_requested, retries) "
             "VALUES (?, ?, ?, ?)",
-            ("https://test1.com", "pending", datetime.now(timezone.utc).isoformat(), 0)
+            ("https://test1.com", "pending",
+             datetime.now(timezone.utc).isoformat(), 0)
         )
         cur.execute(
             "INSERT INTO downloads (url, status, timestamp_requested, retries) "
             "VALUES (?, ?, ?, ?)",
-            ("https://test2.com", "downloaded", datetime.now(timezone.utc).isoformat(), 0)
+            ("https://test2.com", "downloaded",
+             datetime.now(timezone.utc).isoformat(), 0)
         )
         conn.commit()
         conn.close()
@@ -92,7 +94,8 @@ class TestDatabaseUtils(unittest.TestCase):
         cur = conn.cursor()
         cur.execute(
             "INSERT INTO downloads (url, status, timestamp_requested) VALUES (?, ?, ?)",
-            ("https://test.com", "downloading", datetime.now(timezone.utc).isoformat())
+            ("https://test.com", "downloading",
+             datetime.now(timezone.utc).isoformat())
         )
         conn.commit()
         row_id = cur.lastrowid
@@ -126,7 +129,8 @@ class TestDatabaseUtils(unittest.TestCase):
         cur = conn.cursor()
         cur.execute(
             "INSERT INTO downloads (url, status, timestamp_requested) VALUES (?, ?, ?)",
-            ("https://test.com", "downloading", datetime.now(timezone.utc).isoformat())
+            ("https://test.com", "downloading",
+             datetime.now(timezone.utc).isoformat())
         )
         conn.commit()
         row_id = cur.lastrowid

--- a/yt_dl_manager/__main__.py
+++ b/yt_dl_manager/__main__.py
@@ -15,7 +15,8 @@ def main():
     subparsers = parser.add_subparsers(dest="command")
 
     # init command
-    init_parser = subparsers.add_parser("init", help="Create default config file.")
+    init_parser = subparsers.add_parser(
+        "init", help="Create default config file.")
     init_parser.add_argument(
         "-f", "--force", action="store_true", help="Force overwrite of existing config file."
     )
@@ -25,7 +26,8 @@ def main():
 
     # add command
     add_parser = subparsers.add_parser("add", help="Add a video to the queue.")
-    add_parser.add_argument("url", type=str, help="The URL of the video to download.")
+    add_parser.add_argument(
+        "url", type=str, help="The URL of the video to download.")
 
     args = parser.parse_args()
 
@@ -35,6 +37,7 @@ def main():
         daemon_main()
     elif args.command == "add":
         add_to_queue_main(args)
+
 
 if __name__ == "__main__":
     main()

--- a/yt_dl_manager/add_to_queue.py
+++ b/yt_dl_manager/add_to_queue.py
@@ -4,8 +4,10 @@ import sys
 from .queue import Queue
 from .config import get_config_path
 
+
 class AddToQueue:
     """Class to manage adding URLs to the yt-dl-manager queue."""
+
     def __init__(self):
         """Initialize with the database path."""
         self.queue = Queue()
@@ -20,6 +22,7 @@ class AddToQueue:
         """Return the number of items in the queue."""
         return self.queue.get_queue_length()
 
+
 def main(args):
     """Main function for adding a URL to the queue."""
     config_file_path = get_config_path()
@@ -28,6 +31,7 @@ def main(args):
         return
     queue_adder = AddToQueue()
     queue_adder.add_url(args.url)
+
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:

--- a/yt_dl_manager/config.py
+++ b/yt_dl_manager/config.py
@@ -6,10 +6,12 @@ from platformdirs import user_config_dir
 APP_NAME = "yt-dl-manager"
 CONFIG_FILE_NAME = "config.ini"
 
+
 def get_config_path():
     """Get the path to the configuration file."""
     config_dir = Path(user_config_dir(APP_NAME, APP_NAME))
     return config_dir / CONFIG_FILE_NAME
+
 
 def load_config():
     """Load configuration from file."""
@@ -17,5 +19,6 @@ def load_config():
     config_file_path = get_config_path()
     config_parser.read(config_file_path)
     return config_parser
+
 
 config = load_config()

--- a/yt_dl_manager/create_config.py
+++ b/yt_dl_manager/create_config.py
@@ -6,6 +6,7 @@ from platformdirs import user_config_dir, user_data_dir, user_downloads_dir
 APP_NAME = "yt-dl-manager"
 CONFIG_FILE_NAME = "config.ini"
 
+
 def create_default_config(force=False):
     """Create a default configuration file with standard settings."""
     config_dir = Path(user_config_dir(APP_NAME, APP_NAME))
@@ -15,7 +16,8 @@ def create_default_config(force=False):
     config_file_path = config_dir / CONFIG_FILE_NAME
 
     if config_file_path.exists() and not force:
-        print(f"Config file already exists at: {config_file_path}\nUse --force to overwrite.")
+        print(
+            f"Config file already exists at: {config_file_path}\nUse --force to overwrite.")
         return
 
     config = configparser.ConfigParser()

--- a/yt_dl_manager/daemon.py
+++ b/yt_dl_manager/daemon.py
@@ -8,8 +8,10 @@ from .config import config, get_config_path
 POLL_INTERVAL = 10  # seconds
 MAX_RETRIES = 3
 
+
 class YTDLManagerDaemon:
     """Daemon for managing yt-dlp downloads from an SQLite queue."""
+
     def __init__(self):
         """Initialize the daemon with the database path."""
         self.running = True
@@ -86,6 +88,7 @@ class YTDLManagerDaemon:
         except KeyboardInterrupt:
             print('Daemon stopped.')
 
+
 def main():
     """Main function for the daemon."""
     config_file_path = get_config_path()
@@ -94,6 +97,7 @@ def main():
         return
     daemon = YTDLManagerDaemon()
     daemon.run()
+
 
 if __name__ == '__main__':
     main()

--- a/yt_dl_manager/db_utils.py
+++ b/yt_dl_manager/db_utils.py
@@ -13,6 +13,7 @@ class DownloadStatus(Enum):
     DOWNLOADED = 'downloaded'
     FAILED = 'failed'
 
+
 def ensure_database_schema(db_path):
     """Create or verify the downloads table schema.
     Args:
@@ -34,6 +35,7 @@ def ensure_database_schema(db_path):
         # we'll let the error happen later during actual operations
         pass
 
+
 # Database schema definition
 DOWNLOADS_TABLE_SCHEMA = '''
 CREATE TABLE IF NOT EXISTS downloads (
@@ -48,8 +50,10 @@ CREATE TABLE IF NOT EXISTS downloads (
 );
 '''
 
+
 class DatabaseUtils:
     """Centralized database operations for yt-dl-manager."""
+
     def __init__(self, db_path=None):
         """Initialize DatabaseUtils with database path.
         Args:
@@ -172,7 +176,8 @@ class DatabaseUtils:
             cur.execute(
                 f"INSERT INTO downloads (url, status, timestamp_requested) "
                 f"VALUES (?, '{DownloadStatus.PENDING.value}', ?)",
-                (media_url, datetime.datetime.now(datetime.timezone.utc).isoformat())
+                (media_url, datetime.datetime.now(
+                    datetime.timezone.utc).isoformat())
             )
             conn.commit()
             return True, f"URL added to queue: {media_url}"
@@ -212,7 +217,7 @@ class DatabaseUtils:
 
         Returns:
             dict: Dictionary with counts for each status (pending, downloading, downloaded, failed).
-            
+
         Raises:
             sqlite3.OperationalError: If database connection or query fails.
         """
@@ -242,4 +247,5 @@ class DatabaseUtils:
 
             return status_counts
         except sqlite3.OperationalError as e:
-            raise sqlite3.OperationalError(f"Failed to get queue status: {e}") from e
+            raise sqlite3.OperationalError(
+                f"Failed to get queue status: {e}") from e

--- a/yt_dl_manager/queue.py
+++ b/yt_dl_manager/queue.py
@@ -4,6 +4,7 @@ import logging
 from .db_utils import DatabaseUtils
 from .config import config
 
+
 class Queue:
     """Centralized queue management class for yt-dl-manager.
 
@@ -46,12 +47,15 @@ class Queue:
         try:
             result = self.db.add_url(media_url)
             if result[0]:
-                self.logger.info("Successfully added URL to queue: %s", media_url)
+                self.logger.info(
+                    "Successfully added URL to queue: %s", media_url)
             else:
-                self.logger.warning("URL already exists in queue: %s", media_url)
+                self.logger.warning(
+                    "URL already exists in queue: %s", media_url)
             return result
         except Exception as e:
-            self.logger.error("Failed to add URL to queue: %s - %s", media_url, str(e))
+            self.logger.error(
+                "Failed to add URL to queue: %s - %s", media_url, str(e))
             raise
 
     def get_pending(self):
@@ -69,7 +73,8 @@ class Queue:
             self.logger.debug("Found %d pending downloads", len(pending))
             return pending
         except Exception as e:
-            self.logger.error("Failed to retrieve pending downloads: %s", str(e))
+            self.logger.error(
+                "Failed to retrieve pending downloads: %s", str(e))
             raise
 
     def start_download(self, download_id):
@@ -88,9 +93,11 @@ class Queue:
         self.logger.info("Starting download with ID: %d", download_id)
         try:
             self.db.mark_downloading(download_id)
-            self.logger.info("Successfully marked download %d as downloading", download_id)
+            self.logger.info(
+                "Successfully marked download %d as downloading", download_id)
         except Exception as e:
-            self.logger.error("Failed to start download %d: %s", download_id, str(e))
+            self.logger.error(
+                "Failed to start download %d: %s", download_id, str(e))
             raise
 
     def complete_download(self, download_id, filename, extractor):
@@ -112,12 +119,14 @@ class Queue:
         if not isinstance(extractor, str) or not extractor.strip():
             raise ValueError("extractor must be a non-empty string")
 
-        self.logger.info("Completing download %d with filename: %s", download_id, filename)
+        self.logger.info(
+            "Completing download %d with filename: %s", download_id, filename)
         try:
             self.db.mark_downloaded(download_id, filename, extractor)
             self.logger.info("Successfully completed download %d", download_id)
         except Exception as e:
-            self.logger.error("Failed to complete download %d: %s", download_id, str(e))
+            self.logger.error(
+                "Failed to complete download %d: %s", download_id, str(e))
             raise
 
     def fail_download(self, download_id):
@@ -136,9 +145,11 @@ class Queue:
         self.logger.warning("Marking download %d as failed", download_id)
         try:
             self.db.mark_failed(download_id)
-            self.logger.info("Successfully marked download %d as failed", download_id)
+            self.logger.info(
+                "Successfully marked download %d as failed", download_id)
         except Exception as e:
-            self.logger.error("Failed to mark download %d as failed: %s", download_id, str(e))
+            self.logger.error(
+                "Failed to mark download %d as failed: %s", download_id, str(e))
             raise
 
     def retry_download(self, download_id):
@@ -158,9 +169,11 @@ class Queue:
         try:
             self.db.increment_retries(download_id)
             self.db.set_status_to_pending(download_id)
-            self.logger.info("Successfully prepared download %d for retry", download_id)
+            self.logger.info(
+                "Successfully prepared download %d for retry", download_id)
         except Exception as e:
-            self.logger.error("Failed to prepare download %d for retry: %s", download_id, str(e))
+            self.logger.error(
+                "Failed to prepare download %d for retry: %s", download_id, str(e))
             raise
 
     def increment_retries(self, download_id):
@@ -179,7 +192,8 @@ class Queue:
         self.logger.debug("Incrementing retries for download %d", download_id)
         try:
             self.db.increment_retries(download_id)
-            self.logger.debug("Successfully incremented retries for download %d", download_id)
+            self.logger.debug(
+                "Successfully incremented retries for download %d", download_id)
         except Exception as e:
             self.logger.error("Failed to increment retries for download %d: %s",
                               download_id, str(e))
@@ -201,9 +215,11 @@ class Queue:
         self.logger.debug("Setting download %d status to pending", download_id)
         try:
             self.db.set_status_to_pending(download_id)
-            self.logger.debug("Successfully set download %d to pending", download_id)
+            self.logger.debug(
+                "Successfully set download %d to pending", download_id)
         except Exception as e:
-            self.logger.error("Failed to set download %d to pending: %s", download_id, str(e))
+            self.logger.error(
+                "Failed to set download %d to pending: %s", download_id, str(e))
             raise
 
     def get_queue_length(self):


### PR DESCRIPTION
Introduce an `init` command to create a default configuration file for the application, with an option to force overwrite existing files. Refactor code to address pylint issues and enhance test coverage for the new functionality.